### PR TITLE
Add a max pending job option

### DIFF
--- a/bin/slurm_dagman
+++ b/bin/slurm_dagman
@@ -30,7 +30,14 @@ SLURM_DAGMAN_WORKER = None
 def init():
     global SLURM_DAGMAN_WORKER
     try:
-        SLURM_DAGMAN_WORKER = Worker(options['dag_file'], options['outfile'], options['proxy_file'], options['sleep_time'], options['max_jobs_queued'], options['max_jobs_submit'], options['submit_wait_time'])
+        SLURM_DAGMAN_WORKER = Worker(dag_file=options['dag_file'],
+                                     outfile=options['outfile'],
+                                     proxy=options['proxy_file'],
+                                     sleep_time=options['sleep_time'],
+                                     max_jobs_queued=options['max_jobs_queued'],
+                                     max_jobs_pending=options['max_jobs_pending'],
+                                     max_jobs_submit=options['max_jobs_submit'],
+                                     submit_wait_time=options['submit_wait_time'])
     except Exception:
         print('Error running slurm_dagman:\n%s' % (traceback.format_exc()))
         sys.exit(1)

--- a/bin/slurm_submit_dag
+++ b/bin/slurm_submit_dag
@@ -40,6 +40,7 @@ cmd = [slurm_dagman,
        '--outfile', options['outfile'],
        '--sleep-time', '%i' % (options['sleep_time']),
        '--max-jobs-queued', '%i' % (options['max_jobs_queued']),
+       '--max-jobs-pending', '%i' % (options['max_jobs_pending']),
        '--max-jobs-submit', '%i' % (options['max_jobs_submit']),
        '--submit-wait-time', '%i' % (options['submit_wait_time']),
 ]

--- a/etc/SlurmDagman.conf
+++ b/etc/SlurmDagman.conf
@@ -54,6 +54,14 @@
 #   default: 500 (0 or negative = no limit)
 #max_jobs_queued =
 
+# Default value for the command line option '--max-jobs-pending'
+# of the slurm_submit_dag command (and the slurm_dagman executable).
+# Maximum allowed number of jobs that (each instance of) slurm_dagman
+# can be currently pending. Only the general Slurm queue is considered,
+# not a queue per partition.
+#   default: 500 (0 or negative = no limit)
+#max_jobs_pending =
+
 # Default value for the command line option '--max-jobs-submit'
 # of the slurm_submit_dag command (and the slurm_dagman executable).
 # Maximum number of jobs that (each instance of) slurm_dagman can

--- a/lib/SlurmDagman/config/defaults/common.py
+++ b/lib/SlurmDagman/config/defaults/common.py
@@ -7,5 +7,6 @@ DEFAULTS = OrderedDict()
 DEFAULTS['DAGMAN'] = OrderedDict()
 DEFAULTS['DAGMAN']['sleep_time'] = '120'
 DEFAULTS['DAGMAN']['max_jobs_queued'] = '500'
+DEFAULTS['DAGMAN']['max_jobs_pending'] = '500'
 DEFAULTS['DAGMAN']['max_jobs_submit'] = '0'
 DEFAULTS['DAGMAN']['submit_wait_time'] = '2'

--- a/lib/SlurmDagman/config/defaults/common.py
+++ b/lib/SlurmDagman/config/defaults/common.py
@@ -7,6 +7,6 @@ DEFAULTS = OrderedDict()
 DEFAULTS['DAGMAN'] = OrderedDict()
 DEFAULTS['DAGMAN']['sleep_time'] = '120'
 DEFAULTS['DAGMAN']['max_jobs_queued'] = '500'
-DEFAULTS['DAGMAN']['max_jobs_pending'] = '500'
+DEFAULTS['DAGMAN']['max_jobs_pending'] = '0'
 DEFAULTS['DAGMAN']['max_jobs_submit'] = '0'
 DEFAULTS['DAGMAN']['submit_wait_time'] = '2'

--- a/lib/SlurmDagman/process/command/arguments.py
+++ b/lib/SlurmDagman/process/command/arguments.py
@@ -84,6 +84,12 @@ parser.add_argument("--max-jobs-queued",
                     default = int(package_config.get_param('DAGMAN', 'max_jobs_queued')),
                     help = "(maximum number of jobs that can be put in the slurm queue)")
 
+parser.add_argument("--max-jobs-pending",
+                    type = int,
+                    dest = "max_jobs_pending",
+                    default = int(package_config.get_param('DAGMAN', 'max_jobs_pending')),
+                    help = "(maximum number of jobs that are pending in the slurm queue)")
+
 parser.add_argument("--max-jobs-submit",
                     type = int,
                     dest = "max_jobs_submit",

--- a/lib/SlurmDagman/process/command/arguments.py
+++ b/lib/SlurmDagman/process/command/arguments.py
@@ -159,4 +159,5 @@ options['use_proxy'] = args.use_proxy
 options['sleep_time'] = max(args.sleep_time, 0)
 options['max_jobs_queued'] = max(args.max_jobs_queued, 0)
 options['max_jobs_submit'] = max(args.max_jobs_submit, 0)
+options['max_jobs_pending'] = max(args.max_jobs_pending, 0)
 options['submit_wait_time'] = max(args.submit_wait_time, 0)

--- a/lib/SlurmDagman/process/worker.py
+++ b/lib/SlurmDagman/process/worker.py
@@ -303,9 +303,8 @@ class Worker(object):
         self.dag.write(dag_file, use_dag_nodes_appearance_order=True, add_done_labels=add_done_labels)
 
 
-    def __submit_ready_nodes(self):
+    def __submit_ready_nodes(self, num_nodes_pending):
         num_submitted_nodes = 0
-        num_nodes_running, num_nodes_pending, num_nodes_unknown = self.__monitor()
         for node in self.dag:
             if self.max_jobs_queued > 0 and len(self.queued_job_ids) >= self.max_jobs_queued:
                 break
@@ -539,7 +538,7 @@ class Worker(object):
             if self.num_nodes_queued > 0:
                 logging.info('Of %i nodes queued: %i running, %i pending, %i other' % (self.num_nodes_queued, num_nodes_running, num_nodes_pending, num_nodes_unknown))
             if self.num_nodes_ready > 0 and not self.drain and not self.cancel:
-                self.__submit_ready_nodes()
+                self.__submit_ready_nodes(num_nodes_pending=num_nodes_pending)
             else:
                 if self.num_nodes_done == self.num_nodes_total:
                     logging.info('DAG completed successfully.')


### PR DESCRIPTION
Hello,
I've added an option to limit the job submission in function of the number of pending job.
I think this option could be useful to other people.

The option name is --max-jobs-pending with a default value of 500.